### PR TITLE
Fix notes page mobile layout

### DIFF
--- a/frontend/src/components/NoteEditorPage.tsx
+++ b/frontend/src/components/NoteEditorPage.tsx
@@ -88,7 +88,6 @@ const NoteEditorPage: React.FC = () => {
         Upload
       </label>
       <button className="btn-sm btn-gray" onClick={() => noteId ? navigate(`/note/${noteId}/preview`) : navigate('/note')}>Back</button>
-      <button className="btn-sm btn-transparent bg-transparent hover:border-transparent disable">Logout</button>
     </>
   );
 

--- a/frontend/src/components/NotesHeader.tsx
+++ b/frontend/src/components/NotesHeader.tsx
@@ -32,9 +32,13 @@ export const NotesHeader: React.FC<NotesHeaderProps> = ({ rightActions }) => {
             </svg>
           </Link>
           {/* Title linking back to /note */}
-          <Link to="/note" style={{textDecoration:'none', color:'inherit', display:'inline-flex', alignItems:'center', gap:'.5rem'}}>
+          <Link
+            to="/note"
+            className="notes-brand-link"
+            style={{textDecoration:'none', color:'inherit', display:'inline-flex', alignItems:'center', gap:'.5rem'}}
+          >
             <span role="img" aria-label="notes">📝</span>
-            <span>Markdown Notes</span>
+            <span className="notes-brand-title">Markdown Notes</span>
           </Link>
         </div>
         <div className="notes-actions">

--- a/frontend/src/components/NotesPage.tsx
+++ b/frontend/src/components/NotesPage.tsx
@@ -100,7 +100,7 @@ export const NotesPage: React.FC = () => {
       <NotesHeader rightActions={
         <>
           <button className="btn-sm btn-blue" onClick={() => onEdit(undefined)}>Create</button>
-          <label className="btn-sm btn-gray" style={{display:'inline-flex', alignItems:'center', gap:'.25rem', cursor:'pointer'}}>
+          <label className="btn-sm btn-gray notes-upload-button" style={{display:'inline-flex', alignItems:'center', gap:'.25rem', cursor:'pointer'}}>
             <input type="file" accept=".md,.txt" style={{display:'none'}} onChange={async (e) => {
               const f = e.target.files?.[0]; if (!f) return;
               const text = await f.text();
@@ -176,7 +176,7 @@ export const NotesPage: React.FC = () => {
         </div>
 
         {filtered.length > 0 && (
-          <div className="pagination" style={{textAlign:'center', alignItems:'center', marginTop: '1rem', display: 'flex', gap: '5rem', justifyContent: 'center'}}>
+          <div className="pagination notes-pagination">
             <button
               className="btn-sm btn-gray"
               disabled={page <= 1 || loading}

--- a/frontend/src/components/notes.css
+++ b/frontend/src/components/notes.css
@@ -36,7 +36,7 @@
   background: var(--bg);
   color: var(--text);
   min-height: calc(100vh - 3rem);
-  padding: 0.5rem 0 2rem 0; /* prevent top margin collapse causing white bar */
+  padding: 0.5rem 0 2rem 0;
 }
 
 .notes-layout {
@@ -56,14 +56,62 @@
 
 /* Topbar */
 .notes-topbar {
-  position: sticky; top: 0; z-index: 10;
-  background: var(--surface); /* opaque to avoid bleed */
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
 }
-.notes-topbar-inner { max-width: 1200px; margin: 0 auto; padding: 0.75rem 1rem; display: flex; align-items: center; justify-content: space-between; }
-.notes-brand { display: flex; align-items: center; gap: .5rem; color: var(--text-strong); font-weight: 700; }
-.notes-actions { display: flex; gap: .5rem; }
-.btn-sm { padding: 0.45rem .85rem; border-radius: 8px; border: none; font-weight: 600; cursor: pointer; }
+
+.notes-topbar-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.notes-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-strong);
+  font-weight: 700;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.notes-brand-link {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.notes-brand-title {
+  overflow-wrap: anywhere;
+}
+
+.notes-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.btn-sm {
+  padding: 0.45rem 0.85rem;
+  border-radius: 8px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-sm,
+.icon-btn {
+  flex-shrink: 0;
+}
+
 .btn-blue { background: var(--primary); color: #fff; }
 .btn-blue:hover { background: var(--primary-hover); }
 .btn-gray { background: color-mix(in srgb, var(--border) 60%, transparent); color: var(--text-strong); }
@@ -72,54 +120,156 @@
 .btn-red:hover { background: var(--danger-hover); }
 
 /* Uniform square icon buttons for header */
-.icon-btn { width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; border-radius: 8px; border: 1px solid var(--border); background: transparent; color: var(--text); }
+.icon-btn {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+}
+
 .icon-btn:hover { background: var(--link-hover-bg); }
 
 /* Search */
-.notes-search { max-width: 1200px; margin: 1rem auto; padding: 0 1rem; display: flex; gap: .75rem; }
-.notes-search-input { flex: 1; height: 44px; border: 1px solid var(--border); background: var(--surface); color: var(--text); border-radius: 8px; padding: 0 .9rem; font-size: .95rem; }
+.notes-search {
+  max-width: 1200px;
+  margin: 1rem auto;
+  padding: 0 1rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.notes-search-input {
+  flex: 1 1 280px;
+  min-width: 0;
+  height: 44px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 0 0.9rem;
+  font-size: 0.95rem;
+}
+
 .notes-search-input::placeholder { color: var(--text-muted); }
+.notes-search > .btn-sm { flex-shrink: 0; }
 
 /* Grid */
-.notes-grid { max-width: 1200px; margin: 0 auto; padding: 0 1rem; display: grid; gap: 1rem; grid-template-columns: repeat(1, minmax(0,1fr)); }
-@media (min-width: 768px) { .notes-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } }
-@media (min-width: 1024px) { .notes-grid { grid-template-columns: repeat(3, minmax(0,1fr)); } }
-.note-card { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; box-shadow: var(--shadow); padding: 1rem; display: flex; flex-direction: column; gap: .75rem; }
-.note-title { font-weight: 700; color: var(--text-strong); font-size: 1.1rem; }
-.note-updated { font-size: .85rem; color: var(--text-muted); }
-.note-preview { color: var(--text); opacity: .95; max-height: 7.5rem; overflow: hidden; }
+.notes-grid {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(1, minmax(0,1fr));
+}
+
+@media (min-width: 768px) {
+  .notes-grid { grid-template-columns: repeat(2, minmax(0,1fr)); }
+}
+
+@media (min-width: 1024px) {
+  .notes-grid { grid-template-columns: repeat(3, minmax(0,1fr)); }
+}
+
+.note-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.note-title { font-weight: 700; color: var(--text-strong); font-size: 1.1rem; overflow-wrap: anywhere; }
+.note-updated { font-size: 0.85rem; color: var(--text-muted); }
+.note-preview { color: var(--text); opacity: 0.95; max-height: 7.5rem; overflow: hidden; }
 .note-preview.markdown { position: relative; }
-.note-preview.markdown { -webkit-mask-image: linear-gradient(180deg, #000 75%, rgba(0,0,0,0)); mask-image: linear-gradient(180deg, #000 75%, rgba(0,0,0,0)); }
+.note-preview.markdown {
+  -webkit-mask-image: linear-gradient(180deg, #000 75%, rgba(0,0,0,0));
+  mask-image: linear-gradient(180deg, #000 75%, rgba(0,0,0,0));
+}
+
 .markdown { line-height: 1.65; }
 .markdown > * + * { margin-top: 0.6rem; }
 .markdown > :first-child { margin-top: 0; }
 .markdown > :last-child { margin-bottom: 0; }
-.markdown h1, .markdown h2, .markdown h3 { color: var(--text-strong); margin: .6rem 0 .4rem; line-height: 1.25; }
-/* Ensure distinct, readable heading sizes inside markdown */
-.markdown h1 { font-size: 1.8rem; font-weight: 700; padding-top: .4rem; padding-bottom: .4rem; border-bottom: 1px solid var(--border); margin-bottom: .9rem; }
-.markdown h2 { font-size: 1.35rem; font-weight: 700; padding-top: .3rem; padding-bottom: .35rem; border-bottom: 1px solid var(--border); margin-bottom: .8rem; }
-.markdown h3 { font-size: 1.2rem; font-weight: 700; padding-top: .2rem; padding-bottom: .2rem; }
-.markdown h4 { font-size: 1.05rem; font-weight: 600; margin: .5rem 0 .35rem; }
-.markdown h5 { font-size: .98rem; font-weight: 600; margin: .45rem 0 .3rem; }
-.markdown h6 { font-size: .92rem; font-weight: 600; color: var(--text-muted); margin: .4rem 0 .25rem; }
-.markdown p { margin: .6rem 0; white-space: pre-wrap; }
-.markdown ul, .markdown ol { padding-left: 1.25rem; margin: .6rem 0; }
+.markdown h1, .markdown h2, .markdown h3 { color: var(--text-strong); margin: 0.6rem 0 0.4rem; line-height: 1.25; }
+.markdown h1 { font-size: 1.8rem; font-weight: 700; padding-top: 0.4rem; padding-bottom: 0.4rem; border-bottom: 1px solid var(--border); margin-bottom: 0.9rem; }
+.markdown h2 { font-size: 1.35rem; font-weight: 700; padding-top: 0.3rem; padding-bottom: 0.35rem; border-bottom: 1px solid var(--border); margin-bottom: 0.8rem; }
+.markdown h3 { font-size: 1.2rem; font-weight: 700; padding-top: 0.2rem; padding-bottom: 0.2rem; }
+.markdown h4 { font-size: 1.05rem; font-weight: 600; margin: 0.5rem 0 0.35rem; }
+.markdown h5 { font-size: 0.98rem; font-weight: 600; margin: 0.45rem 0 0.3rem; }
+.markdown h6 { font-size: 0.92rem; font-weight: 600; color: var(--text-muted); margin: 0.4rem 0 0.25rem; }
+.markdown p { margin: 0.6rem 0; white-space: pre-wrap; }
+.markdown ul, .markdown ol { padding-left: 1.25rem; margin: 0.6rem 0; }
 .markdown ul { list-style-type: disc; }
 .markdown ol { list-style-type: decimal; }
 .markdown li ul { list-style-type: circle; }
 .markdown li ol { list-style-type: lower-alpha; }
-.markdown li { margin: .25rem 0; }
-.markdown table { width: 100%; border-collapse: collapse; margin: .75rem 0; font-size: .95rem; }
+.markdown li { margin: 0.25rem 0; }
+.markdown table { width: 100%; border-collapse: collapse; margin: 0.75rem 0; font-size: 0.95rem; }
 .markdown thead { background: color-mix(in srgb, var(--border) 70%, transparent); }
-.markdown th, .markdown td { border: 1px solid var(--border); padding: .4rem .6rem; vertical-align: top; }
+.markdown th, .markdown td { border: 1px solid var(--border); padding: 0.4rem 0.6rem; vertical-align: top; }
 .markdown tbody tr:nth-child(even) { background: color-mix(in srgb, var(--border) 50%, transparent); }
 .markdown a { color: var(--primary); text-decoration: underline; text-underline-offset: 0.12em; }
 .markdown a:hover { color: var(--primary-hover); }
-.markdown code { background: color-mix(in srgb, var(--border) 65%, transparent); padding: .1rem .3rem; border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-.markdown pre { background: color-mix(in srgb, var(--border) 75%, transparent); border: 1px solid var(--border); padding: .6rem .8rem; border-radius: 8px; overflow: auto; margin: .75rem 0; }
-.markdown blockquote { border-left: 3px solid var(--border); padding-left: .75rem; color: var(--text-muted); margin: .75rem 0; }
-.markdown hr { border: 0; border-top: 1px solid var(--border); margin: .9rem 0; }
-.note-buttons { display: flex; gap: .5rem; margin-top: auto; }
+.markdown code {
+  background: color-mix(in srgb, var(--border) 65%, transparent);
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.markdown pre {
+  background: color-mix(in srgb, var(--border) 75%, transparent);
+  border: 1px solid var(--border);
+  padding: 0.6rem 0.8rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  max-width: 100%;
+  margin: 0.75rem 0;
+}
+.markdown blockquote { border-left: 3px solid var(--border); padding-left: 0.75rem; color: var(--text-muted); margin: 0.75rem 0; }
+.markdown hr { border: 0; border-top: 1px solid var(--border); margin: 0.9rem 0; }
+.note-buttons { display: flex; gap: 0.5rem; margin-top: auto; flex-wrap: wrap; }
+
+.notes-pagination {
+  text-align: center;
+  align-items: center;
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  padding: 0 1rem;
+}
+
+.notes-upload-button {
+  justify-content: center;
+}
+
+.note-card,
+.notes-grid,
+.notes-search,
+.notes-topbar-inner,
+.notes-brand,
+.notes-actions {
+  min-width: 0;
+}
+
+.markdown table {
+  display: block;
+  overflow-x: auto;
+}
 
 /* Modal */
 .notes-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.5); display: flex; align-items: center; justify-content: center; z-index: 40; }
@@ -170,7 +320,54 @@
 .btn-secondary:hover { background: color-mix(in srgb, var(--border) 75%, transparent); }
 .btn-danger { background: var(--danger); color: #fff; }
 .btn-danger:hover { background: var(--danger-hover); }
-.notes-modal-body { display: grid; gap: .75rem; grid-template-columns: 1fr; }
+.notes-modal-body { display: grid; gap: 0.75rem; grid-template-columns: 1fr; }
 @media (min-width: 900px) { .notes-modal-body { grid-template-columns: 1fr 1fr; } }
-.notes-preview { border: 1px solid var(--border); background: var(--surface); border-radius: 8px; padding: .6rem .75rem; min-height: 18rem; max-height: 60vh; overflow: auto; }
-.notes-preview .markdown { font-size: .95rem; }
+.notes-preview { border: 1px solid var(--border); background: var(--surface); border-radius: 8px; padding: 0.6rem 0.75rem; min-height: 18rem; max-height: 60vh; overflow: auto; }
+.notes-preview .markdown { font-size: 0.95rem; }
+
+@media (max-width: 767px) {
+  .notes-topbar-inner {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .notes-brand {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .notes-brand-link {
+    flex-basis: 100%;
+  }
+
+  .notes-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .notes-actions .btn-sm,
+  .notes-search > .btn-sm,
+  .note-buttons .btn-sm {
+    flex: 1 1 calc(50% - 0.375rem);
+    min-width: 0;
+    text-align: center;
+  }
+
+  .note-card {
+    padding: 0.875rem;
+  }
+}
+
+@media (max-width: 479px) {
+  .notes-actions .btn-sm,
+  .notes-upload-button,
+  .notes-search > .btn-sm,
+  .note-buttons .btn-sm,
+  .notes-pagination .btn-sm {
+    flex-basis: 100%;
+  }
+
+  .notes-pagination {
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- remove the stray logout button from the note editor header
- make the notes header and action buttons wrap correctly on smaller screens
- improve mobile layout for search actions, pagination, note cards, and markdown overflow

## Validation
- `pnpm build` in `frontend/`

Closes #6.