### PR TITLE
Fix Notes page mobile header layout

### DIFF
--- a/frontend/src/components/notes.css
+++ b/frontend/src/components/notes.css
@@ -326,7 +326,12 @@
 .notes-preview .markdown { font-size: 0.95rem; }
 
 @media (max-width: 767px) {
+  .notes-topbar {
+    position: static;
+  }
+
   .notes-topbar-inner {
+    padding: 0.625rem 0.75rem;
     align-items: stretch;
     flex-direction: column;
   }
@@ -334,15 +339,35 @@
   .notes-brand {
     width: 100%;
     justify-content: flex-start;
+    gap: 0.375rem;
   }
 
   .notes-brand-link {
     flex-basis: 100%;
   }
 
+  .notes-brand-title {
+    font-size: 0.95rem;
+  }
+
   .notes-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .notes-topbar .btn-sm {
+    padding: 0.375rem 0.7rem;
+    font-size: 0.875rem;
+  }
+
+  .notes-topbar .icon-btn {
+    width: 36px;
+    height: 36px;
+  }
+
+  .notes-topbar .icon-btn svg {
+    width: 18px;
+    height: 18px;
   }
 
   .notes-actions .btn-sm,


### PR DESCRIPTION
## Summary
- make the Notes header scroll with the page on mobile instead of staying sticky
- reduce header spacing and title size on small screens
- shrink Notes header action buttons and icon buttons in mobile view

## Verification
- `pnpm build`

Closes #10.